### PR TITLE
Fix example on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ This can be piped in different ways. For example, to a file::
 
 Or to export the collection into CrateDB using `cr8`_::
 
-    migr8 export --host localhost -- port -- database test_db --collection test | \
+    migr8 export --host localhost --port 27017 --database test_db --collection test | \
         cr8 insert-json --hosts localhost:4200 --table test
 
 Development Sandbox


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
One of the example command on the `README` was not working due to extra spaces and a missing value in `--port`

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
