### PR TITLE
Add basic integration test with CI test matrix for MongoDB 2, 3, 4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.11"]
-        mongodb-version: ["4","5"]
+        mongodb-version: ["2", "3", "4"]
 
     # Run auxiliary services. Works for all runner OS, because it is independent.
     # https://docs.github.com/en/actions/using-containerized-services/about-service-containers

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,12 +24,22 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.11"]
+        mongodb-version: ["4","5"]
+
+    # Run auxiliary services. Works for all runner OS, because it is independent.
+    # https://docs.github.com/en/actions/using-containerized-services/about-service-containers
+    services:
+
+      mongodb:
+        image: mongo:${{ matrix.mongodb-version }}
+        ports:
+          - 27017:27017
 
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
 
-    name: Python ${{ matrix.python-version }} on OS ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }}, MongoDB ${{ matrix.mongodb-version }} on OS ${{ matrix.os }}
     steps:
 
     - name: Acquire sources

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ Unreleased
 ==========
 
 - Fix installation by adjusting dependencies
+- CI: Add support for MongoDB 2-4
 
 01/09/2020 0.2.0
 ================

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-MongoDB → CrateDB Schema Extractor
-==================================
+MongoDB → CrateDB Migration Tool
+================================
 
 This tool iterates over a MongoDB collection (or series of collections) and
 iteratively builds up a description of the schema of that collection. This
@@ -8,6 +8,12 @@ to determine a best-fit table definition for that schema.
 
 As such, this means the tool works best on collections of similarly structured
 and typed data.
+
+The application supports the following versions of MongoDB.
+
+.. image:: https://img.shields.io/badge/MongoDB-2.x%20--%204.x-blue.svg
+    :target: https://github.com/mongodb/mongo
+    :alt: Supported MongoDB versions
 
 Installation
 ------------
@@ -168,7 +174,7 @@ Acquire sources, and install package in development mode::
 
 Start a sandbox instance of MongoDB in another terminal::
 
-    docker run -it --rm --publish=27017:27017 mongo:5
+    docker run -it --rm --publish=27017:27017 mongo:4
 
 Run the software tests::
 

--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,10 @@ Acquire sources, and install package in development mode::
     source .venv/bin/activate
     pip install --editable='.[testing]'
 
+Start a sandbox instance of MongoDB in another terminal::
+
+    docker run -it --rm --publish=27017:27017 mongo:5
+
 Run the software tests::
 
     python -m unittest -vvv

--- a/crate/migr8/__main__.py
+++ b/crate/migr8/__main__.py
@@ -139,6 +139,10 @@ def gather_collections(database):
         if i not in collections_to_ignore:
             filtered_collections.append(c)
 
+    # MongoDB 2 does not understand `include_system_collections=False`.
+    if "system.indexes" in filtered_collections:
+        filtered_collections.remove("system.indexes")
+
     return filtered_collections
 
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -48,9 +48,6 @@ class TestMongoDBIntegration(unittest.TestCase):
 
     # MongoDB 4
     docker run -it --rm --publish=27017:27017 mongo:4
-
-    # MongoDB 5
-    docker run -it --rm --publish=27017:27017 mongo:5
     """
 
     HOST = "localhost"

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,4 +1,8 @@
-from crate.migr8.__main__ import parse_input_numbers
+from unittest import mock
+
+import pymongo
+
+from crate.migr8.__main__ import parse_input_numbers, gather_collections
 
 import unittest
 
@@ -33,3 +37,56 @@ class TestInputNumberParser(unittest.TestCase):
         s = "0 1, 3 5-8, 9 12-10"
         parsed = parse_input_numbers(s)
         self.assertEqual(parsed, [0, 1, 3, 5, 6, 7, 8, 9, 10, 11, 12])
+
+
+class TestMongoDBIntegration(unittest.TestCase):
+    """
+    A few conditional integration test cases with MongoDB.
+
+    It can be configured to not fail the test suite when no MongoDB server
+    is running. In order to provide an instance easily, use Docker or Podman.
+
+    # MongoDB 4
+    docker run -it --rm --publish=27017:27017 mongo:4
+
+    # MongoDB 5
+    docker run -it --rm --publish=27017:27017 mongo:5
+    """
+
+    HOST = "localhost"
+    PORT = 27017
+    DBNAME = "testdrive"
+    TIMEOUT_MS = 200
+
+    SKIP_IF_NOT_RUNNING = False
+
+    @classmethod
+    def setUpClass(cls):
+        cls.client = pymongo.MongoClient(
+            host=cls.HOST,
+            port=cls.PORT,
+            connectTimeoutMS=cls.TIMEOUT_MS,
+            serverSelectionTimeoutMS=cls.TIMEOUT_MS,
+        )
+        cls.db = cls.client.get_database(cls.DBNAME)
+        try:
+            cls.db.last_status()
+        except pymongo.errors.ServerSelectionTimeoutError:
+            if cls.SKIP_IF_NOT_RUNNING:
+                raise cls.skipTest(cls, reason="MongoDB server not running")
+            else:
+                raise
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.client.drop_database(cls.DBNAME)
+        cls.client.close()
+
+    def test_gather_collections(self):
+        """
+        Verify if core method `gather_collections` works as expected.
+        """
+        self.db.create_collection("foobar")
+        with mock.patch("builtins.input", return_value="unknown"):
+            collections = gather_collections(database=self.db)
+            self.assertEqual(collections, ["foobar"])


### PR DESCRIPTION
## Problem

GH-5 outlined that this program is not compatible with MongoDB 5 yet.

## Yak Shaving

In order to better catch such situations, this patch adds a basic integration test case for MongoDB, and verifies it on CI using MongoDB 2, 3, and 4.

/cc @karynzv, @hlcianfagna, @ckurze