### PR TITLE
Unlock supporting MongoDB 5, 6, 7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.11"]
-        mongodb-version: ["2", "3", "4"]
+        mongodb-version: ["2", "3", "4", "5", "6", "7"]
 
     # Run auxiliary services. Works for all runner OS, because it is independent.
     # https://docs.github.com/en/actions/using-containerized-services/about-service-containers

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,11 @@ jobs:
         # Install package in editable mode.
         pip install --use-pep517 --prefer-binary --editable='.[testing]'
 
+    - name: Downgrade pymongo on MongoDB 2
+      if: matrix.mongodb-version == '2'
+      run: |
+        pip install 'pymongo<4'
+
     - name: Run linter and software tests
       run: |
         python -m unittest -vvv

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,7 +6,7 @@ Unreleased
 ==========
 
 - Fix installation by adjusting dependencies
-- CI: Add support for MongoDB 2-4
+- Add support for MongoDB 2 to 7
 - MongoDB API: ``include_system_collections`` became an unknown BSON field
 - Update to pymongo 4
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ Unreleased
 
 - Fix installation by adjusting dependencies
 - CI: Add support for MongoDB 2-4
+- MongoDB API: ``include_system_collections`` became an unknown BSON field
 
 01/09/2020 0.2.0
 ================

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ Unreleased
 - Fix installation by adjusting dependencies
 - CI: Add support for MongoDB 2-4
 - MongoDB API: ``include_system_collections`` became an unknown BSON field
+- Update to pymongo 4
 
 01/09/2020 0.2.0
 ================

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Supported MongoDB versions
 
 The application supports the following versions of MongoDB.
 
-.. image:: https://img.shields.io/badge/MongoDB-2.x%20--%204.x-blue.svg
+.. image:: https://img.shields.io/badge/MongoDB-2.x%20--%207.x-blue.svg
     :target: https://github.com/mongodb/mongo
     :alt: Supported MongoDB versions
 
@@ -181,7 +181,11 @@ Acquire sources, and install package in development mode::
 
 Start a sandbox instance of MongoDB in another terminal::
 
+    # MongoDB 4
     docker run -it --rm --publish=27017:27017 mongo:4
+
+    # MongoDB 7
+    docker run -it --rm --publish=27017:27017 mongo:7
 
 Run the software tests::
 

--- a/README.rst
+++ b/README.rst
@@ -9,11 +9,18 @@ to determine a best-fit table definition for that schema.
 As such, this means the tool works best on collections of similarly structured
 and typed data.
 
+Supported MongoDB versions
+--------------------------
+
 The application supports the following versions of MongoDB.
 
 .. image:: https://img.shields.io/badge/MongoDB-2.x%20--%204.x-blue.svg
     :target: https://github.com/mongodb/mongo
     :alt: Supported MongoDB versions
+
+If you need support for MongoDB 2.x, you will need to downgrade the ``pymongo``
+client driver library to version 3, like ``pip install 'pymongo<4'`.
+
 
 Installation
 ------------

--- a/crate/migr8/__main__.py
+++ b/crate/migr8/__main__.py
@@ -119,7 +119,7 @@ def gather_collections(database):
     on user input.
     """
 
-    collections = database.list_collection_names(include_system_collections=False)
+    collections = database.list_collection_names()
 
     tbl = rich.table.Table(show_header=True, header_style="bold blue")
     tbl.add_column("Id", width=3)
@@ -140,8 +140,7 @@ def gather_collections(database):
             filtered_collections.append(c)
 
     # MongoDB 2 does not understand `include_system_collections=False`.
-    if "system.indexes" in filtered_collections:
-        filtered_collections.remove("system.indexes")
+    filtered_collections = [item for item in filtered_collections if not item.startswith("system.")]
 
     return filtered_collections
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     namespace_packages=["crate"],
     entry_points={"console_scripts": ["migr8 = crate.migr8.__main__:main"]},
     install_requires=[
-        "pymongo>=3.10.1,<4",
+        "pymongo>=3.10.1,<5",
         "rich>=3.3.2,<4",
         "orjson>=3.3.1,<4",
         "python-bsonjs>=0.2,<0.3",

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -67,7 +67,7 @@ class TestMongoDBIntegration(unittest.TestCase):
         )
         cls.db = cls.client.get_database(cls.DBNAME)
         try:
-            cls.db.last_status()
+            cls.client.server_info()
         except pymongo.errors.ServerSelectionTimeoutError:
             if cls.SKIP_IF_NOT_RUNNING:
                 raise cls.skipTest(cls, reason="MongoDB server not running")


### PR DESCRIPTION
## Problem

GH-5 outlined that this program is not even compatible with MongoDB 5 yet, while MongoDB 7 is being published already. 

## Solution

This patch aims to modernize accordingly.

## Outcome

> **Supported MongoDB versions**
> 
> The application supports the following versions of MongoDB.
>
> ![image](https://img.shields.io/badge/MongoDB-2.x%20--%207.x-blue.svg)
> 
> If you need support for MongoDB 2.x, you will need to downgrade the ``pymongo``
client driver library to version 3, like `pip install 'pymongo<4'`.

/cc @karynzv, @hlcianfagna, @ckurze