### PR TITLE
README: Add migration notice about CrateDB Toolkit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,38 @@
 MongoDB → CrateDB Migration Tool
 ================================
 
+Migration Notice
+----------------
+
+**The code in this repository has been integrated into the** `CrateDB Toolkit`_.
+
+Please switch over by invoking::
+
+    pip uninstall migr8
+    pip install cratedb-toolkit
+
+CrateDB Toolkit provides the same `migr8`_ command-line interface as before,
+and an additional `ctk load table`_ one-shot command-line interface. It works
+like this::
+
+    ctk load table \
+      --cratedb-sqlalchemy-url crate://crate@localhost:4200/testdrive/demo \
+      mongodb://localhost:27017/testdrive/demo
+
+In order to run the commands without installation, or on cloud environments,
+you can now also use an OCI image, for example with Podman or Docker::
+
+    alias ctk="docker run -it --rm ghcr.io/crate-workbench/cratedb-toolkit ctk"
+    alias migr8="docker run -it --rm ghcr.io/crate-workbench/cratedb-toolkit migr8"
+
+To verify that works well, run::
+
+    ctk load table --help
+    migr8 --help
+
+About
+-----
+
 This tool iterates over a MongoDB collection (or series of collections) and
 iteratively builds up a description of the schema of that collection. This
 description can then be used to create a CrateDB schema, which will attempt
@@ -222,5 +254,8 @@ release page`_.
 
 
 .. _cr8: https://github.com/mfussenegger/cr8
-.. _shiv: https://github.com/linkedin/shiv
+.. _CrateDB Toolkit: https://github.com/crate-workbench/cratedb-toolkit
+.. _ctk load table: https://github.com/crate-workbench/cratedb-toolkit/tree/main/cratedb_toolkit/io#mongodb
 .. _GitHub release page: https://github.com/crate/mongodb-cratedb-migration-tool/releases
+.. _migr8: https://github.com/crate-workbench/cratedb-toolkit/tree/main/cratedb_toolkit/io/mongodb#readme
+.. _shiv: https://github.com/linkedin/shiv


### PR DESCRIPTION
## About
The code in this repository has been integrated into [CrateDB Toolkit](https://github.com/crate-workbench/cratedb-toolkit) on Nov 13, 2023 already, shortly after tagging [version 0.3.0](https://github.com/crate/mongodb-cratedb-migration-tool/releases/tag/0.3.0) supported by @karynzv, thank you.

- https://github.com/crate-workbench/cratedb-toolkit/pull/76

## Rationale
`migr8` never made it to PyPI, or into an OCI image. With CrateDB Toolkit, you have both benefits, so you can deploy it much easier, and also use it as a library.

## Patch
In order to conclude the migration, this patch adjusts the README to educate users about the situation. After that, the repository will be archived.

**Preview:** [New README](https://github.com/crate/mongodb-cratedb-migration-tool/blob/amo/migration-notice/README.rst)

## Trivia
Integration tests of the code at the new location against CrateDB Nightly and all available MongoDB versions 2.x-7.x will be invoked each night, their outcome is reflected through the [Ecosystem Build Status](https://cratedb.com/docs/crate/clients-tools/en/latest/status.html) page on behalf of the Toolkit+MongoDB badge.

<a href="https://github.com/crate-workbench/cratedb-toolkit/actions/workflows//mongodb.yml">
  <img src="https://img.shields.io/github/actions/workflow/status/crate-workbench/cratedb-toolkit/mongodb.yml?label=Toolkit%2BMongoDB" loading="lazy"></a>
<br><br>

/cc @karynzv, @hlcianfagna, @surister, @wierdvanderhaar 